### PR TITLE
Publish.svelte: improve pattern matching

### DIFF
--- a/philip/src/components/Publish.svelte
+++ b/philip/src/components/Publish.svelte
@@ -28,7 +28,6 @@
       .map(v => v.trim())
       .map(getHashTag);
 
-    const data = wrapHashTagsWithLink(content);
     const data = wrapHashTagsWithLink(wrapLinksWithTags(content));
 
     let ap_object = getCreateObject(data, tags);

--- a/philip/src/components/Publish.svelte
+++ b/philip/src/components/Publish.svelte
@@ -8,7 +8,7 @@
   let inProgress = false;
   let content = "";
 
-  const hashTagMatcher = /(^|\W)(#[a-z\d][\w-]*)/gi;
+  const hashTagMatcher = /(^|\W)(#[^#\s]+)/gi;
 
   const wrapHashTagsWithLink = text =>
     text.match(hashTagMatcher)
@@ -16,6 +16,9 @@
       : text;
 
   const getAllHashTags = text => text.match(hashTagMatcher) || [];
+
+  const wrapLinksWithTags = text =>
+    text.replace(/(https?:\/\/([^\s]+))/gi, '<a href="$1">$2</a>');
 
   const publish = async ev => {
     ev.preventDefault();
@@ -26,6 +29,7 @@
       .map(getHashTag);
 
     const data = wrapHashTagsWithLink(content);
+    const data = wrapHashTagsWithLink(wrapLinksWithTags(content));
 
     let ap_object = getCreateObject(data, tags);
 


### PR DESCRIPTION
- make hashtag parser more tolerant (#9)
- wrap URLs with 'a' tag (#10)