### PR TITLE
WIP implement mentions + findUser falls back to webfinger

### DIFF
--- a/philip/src/components/Publish.svelte
+++ b/philip/src/components/Publish.svelte
@@ -8,63 +8,66 @@
 
   let inProgress = false;
   let content = "";
+  let error = "";
 
   const hashTagMatcher = /(^|\W)(#[^#\s]+)/gi;
-  const mentionMatcher = /(^|\W)@([^@\s]+)/gi;
+  const mentionMatcher = /(^|\W)@([^@\s]+)(@([^@\s]+))?/gi;
 
   const wrapHashTagsWithLink = text =>
-    text.match(hashTagMatcher)
-      ? text.replace(hashTagMatcher, '$1<a href="" rel="tag">$2</a>')
-      : text;
-  const wrapMentions = text =>
-    text.match(mentionMatcher)
-      ? text.replace(
-          mentionMatcher,
-          "$1<span class='h-card'><a href='" +
-            getUserId("$2") +
-            "' class='u-url mention'>@<span>$2</span></a></span>"
-        )
-      : text;
+    text.replace(hashTagMatcher, '$1<a href="" rel="tag">$2</a>');
 
   const getAllHashTags = text => text.match(hashTagMatcher) || [];
-  const getAllMentions = text => text.match(mentionMatcher) || [];
+  const getAllMentions = text => [...text.matchAll(mentionMatcher)] || [];
 
   const wrapLinksWithTags = text =>
     text.replace(/(https?:\/\/([^\s]+))/gi, '<a href="$1">$2</a>');
 
-  const publish = async ev => {
+  const publish = ev => {
     ev.preventDefault();
-
     inProgress = true;
-    let tags = getAllHashTags(content)
+
+    const tags = getAllHashTags(content)
       .map(v => v.trim())
       .map(getHashTag);
-    let mentions = getAllMentions(content)
-      .map(m => m.trim())
-      .map(m => getMention(m, getUserId(m)));
+    content = wrapHashTagsWithLink(wrapLinksWithTags(content));
 
-    const data = wrapMentions(wrapHashTagsWithLink(wrapLinksWithTags(content)));
-    let ap_object = getCreateObject(data, tags.concat(mentions));
+    // parse and replace mentions
+    const mentions = getAllMentions(content).map(m => {
+      const orig = m[0];
+      const name = m[2];
+      const domain = m[4];
+      const id = getUserId(name, domain);
+      const wrapped = `${m[1]}<span class='h-card'><a href="${id}"' class='u-url mention'>@<span>${name}</span></a></span>`;
+      content = content.replace(orig, wrapped);
+      return getMention(name, id);
+    });
+    let ap_object = getCreateObject(content, tags.concat(mentions));
     ap_object.cc = mentions.map(m => m.href);
 
     if (reply) {
       ap_object.object.inReplyTo = reply.id;
       ap_object.cc = ap_object.cc.concat(reply.attributedTo);
     }
+    sendPost(JSON.stringify(ap_object));
+  };
 
+  const sendPost = async body => {
     try {
-      const response = await fetch($session.user.outbox, {
-        method: "POST",
-        body: JSON.stringify(ap_object),
-        headers: { Authorization: "Bearer " + $session.token },
-      });
-      const data = await response.json();
+      const headers = { Authorization: "Bearer " + $session.token };
+      const req = { method: "POST", body, headers };
+      console.log("sending", req);
+      const res = await fetch($session.user.outbox, req).then(d => d.json());
+      console.log("response", res);
+      if (res.error) error = res.error;
+      else if (res.Created !== "success")
+        error = "Failed to create post: " + JSON.stringify(res);
     } catch (e) {
-      console.log(e);
+      error = e;
     }
 
     inProgress = false;
     content = "";
+    // TODO change route to show post?
   };
 </script>
 
@@ -90,3 +93,5 @@
   </button>
 
 </form>
+
+<p class="text-danger">{error}</p>

--- a/philip/src/utils/index.js
+++ b/philip/src/utils/index.js
@@ -1,2 +1,3 @@
 export { default as xhr } from "./xhr";
 export { ensureObject } from "./objectUtils";
+export { getUserId } from "./user";

--- a/philip/src/utils/index.js
+++ b/philip/src/utils/index.js
@@ -1,3 +1,3 @@
 export { default as xhr } from "./xhr";
 export { ensureObject } from "./objectUtils";
-export { getUserId } from "./user";
+export { getUserId, findUser, fetchUser, fetchOutbox } from "./user";

--- a/philip/src/utils/pubGate.js
+++ b/philip/src/utils/pubGate.js
@@ -1,8 +1,6 @@
-export const getHashTag = name => ({
-  name,
-  href: "",
-  type: "Hashtag",
-});
+export const getHashTag = name => ({ name, href: "", type: "Hashtag" });
+
+export const getMention = (name, href) => ({ name, href, type: "Mention" });
 
 export const getCreateObject = (content, tag) => ({
   type: "Create",

--- a/philip/src/utils/user.js
+++ b/philip/src/utils/user.js
@@ -1,0 +1,5 @@
+export const getUserId = name => {
+  // TODO implement webFinger (#26)
+  const id = `${base_url}/@${name}`; // FollowYourNose
+  return id;
+};

--- a/philip/src/utils/user.js
+++ b/philip/src/utils/user.js
@@ -1,5 +1,56 @@
-export const getUserId = name => {
-  // TODO implement webFinger (#26)
-  const id = `${base_url}/@${name}`; // FollowYourNose
-  return id;
+let baseProtocol, baseDomain;
+const m = base_url.match(/^([^:]+):\/\/([^/]+)/);
+if (m) {
+  baseProtocol = m[1];
+  baseDomain = m[2];
+}
+
+export const getUserId = (name, domain = baseDomain, fyn = true) => {
+  const protocol = domain === baseDomain ? baseProtocol : "https";
+  return (
+    `${protocol}://${domain}/` +
+    (fyn ? `@${name}` : `.well-known/webfinger?resource=acc:${name}@${domain}`)
+  );
+};
+
+export const findUser = async (name, domain) => {
+  const useProxy = pubgate_instance ? true : false;
+  const fynRes = await fetchUser(getUserId(name, domain), useProxy);
+  console.log("fyn", fynRes);
+  if (fynRes && !fynRes.error) return fynRes;
+
+  const wfRes = await fetchUser(getUserId(name, domain, false), useProxy);
+  console.log("wf", wfRes);
+  if (!wfRes || wfRes.error) return wfRes;
+  const id = wfRes.aliases[1] || wfRes.links[0].href;
+  return await fetchUser(id, useProxy);
+};
+
+export const fetchUser = async (url, useProxy = true) => {
+  if (useProxy) {
+    //TODO require auth, merge with xhr?
+    const req = { method: "POST", body: JSON.stringify({ url }) };
+    return await fetch(base_url + "/proxy", req).then(d => d.json());
+  }
+  try {
+    // might not return json
+    const headers = { Accept: "application/activity+json" };
+    return await fetch(url, headers).then(d => d.json());
+  } catch (error) {
+    return { error };
+  }
+};
+
+export const fetchOutbox = async url => {
+  const req = { method: "POST", body: JSON.stringify({ url }) };
+  const res = await fetch(base_url + "/proxy", req).then(d => d.json());
+  if (res.error) return res;
+  return typeof res.first === "string"
+    ? await fetchTimeline(res.first)
+    : res.first;
+};
+
+const fetchTimeline = async url => {
+  const req = { method: "POST", body: JSON.stringify({ url }) };
+  return await fetch(base_url + "/proxy", request).then(d => d.json());
 };


### PR DESCRIPTION
see #26, #27

1. [X] match @user@domain or @user (base_url is used)
1. [X] wrap in html
1. [X] create mention object
1. [X] add cc
1. [ ] test search with non-pgi

Note: the output specification requires `"cc": [<user_id>]`. When mentioning multiple users backend raised 500 because the cc list was inserted as an array. Hence line 46 in *Publish.svelte* is `ap_object.cc = mentions.map(m => m.href);` instead of `ap_object.cc = [mentions.map(m => m.href)];`